### PR TITLE
[COMPOSE] Share fragment

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,10 @@ buildscript {
         lifecycleLiveData = "2.4.1"
         biometricVersion="1.1.0"
         androidX = '1.0.0'
+        compose_version = '1.1.1'
 
         // Kotlin
-        kotlinVersion = "1.6.21"
+        kotlinVersion = "1.6.10"
         coroutinesVersion = "1.6.1"
 
         // Koin

--- a/owncloudApp/build.gradle
+++ b/owncloudApp/build.gradle
@@ -93,7 +93,7 @@ dependencies {
 
     debugImplementation "androidx.fragment:fragment-testing:1.4.1"
     debugImplementation 'com.facebook.stetho:stetho:1.6.0'
-    debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.8.1'
+    //debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.8.1'
 }
 
 android {

--- a/owncloudApp/build.gradle
+++ b/owncloudApp/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     implementation "androidx.core:core-ktx:$ktxCoreVersion"
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$ktxViewModelVersion"
     implementation "androidx.fragment:fragment-ktx:$ktxFragmentVersion"
+    implementation "androidx.compose.runtime:runtime-livedata:1.1.1"
 
     // Preferences
     implementation 'androidx.preference:preference-ktx:1.2.0'

--- a/owncloudApp/build.gradle
+++ b/owncloudApp/build.gradle
@@ -63,6 +63,11 @@ dependencies {
     // MDM feedback
     implementation 'androidx.enterprise:enterprise-feedback:1.1.0'
 
+    // Jetpack Compose
+    implementation "androidx.compose.ui:ui:$compose_version"
+    implementation "androidx.compose.material:material:$compose_version"
+    implementation 'androidx.activity:activity-compose:1.4.0'
+
     // Tests
     testImplementation project(':owncloudTestUtil')
     testImplementation "junit:junit:$junitVersion"
@@ -94,6 +99,9 @@ dependencies {
     debugImplementation "androidx.fragment:fragment-testing:1.4.1"
     debugImplementation 'com.facebook.stetho:stetho:1.6.0'
     //debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.8.1'
+
+    // Jetpack Compose
+    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
 }
 
 android {
@@ -115,6 +123,14 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+    }
+
+    buildFeatures {
+        compose true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion compose_version
     }
 
     kotlinOptions {

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/ShareActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/ShareActivity.kt
@@ -74,7 +74,6 @@ class ShareActivity : FileActivity(), ShareFragmentListener {
         supportFragmentManager.transaction {
             if (savedInstanceState == null && file != null && account != null) {
                 // Add Share fragment on first creation
-                // val fragment = ShareFileFragment.newInstance(file, account!!)
                 val fragment = ShareFileComposeFragment.newInstance(file, account)
                 replace(
                     R.id.share_fragment_container, fragment,

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/ShareActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/ShareActivity.kt
@@ -41,6 +41,7 @@ import com.owncloud.android.presentation.providers.sharing.UsersAndGroupsSearchP
 import com.owncloud.android.presentation.ui.sharing.fragments.EditPrivateShareFragment
 import com.owncloud.android.presentation.ui.sharing.fragments.PublicShareDialogFragment
 import com.owncloud.android.presentation.ui.sharing.fragments.SearchShareesFragment
+import com.owncloud.android.presentation.ui.sharing.fragments.ShareFileComposeFragment
 import com.owncloud.android.presentation.ui.sharing.fragments.ShareFileFragment
 import com.owncloud.android.presentation.ui.sharing.fragments.ShareFragmentListener
 import com.owncloud.android.presentation.viewmodels.sharing.OCShareViewModel
@@ -73,7 +74,8 @@ class ShareActivity : FileActivity(), ShareFragmentListener {
         supportFragmentManager.transaction {
             if (savedInstanceState == null && file != null && account != null) {
                 // Add Share fragment on first creation
-                val fragment = ShareFileFragment.newInstance(file, account!!)
+                // val fragment = ShareFileFragment.newInstance(file, account!!)
+                val fragment = ShareFileComposeFragment()
                 replace(
                     R.id.share_fragment_container, fragment,
                     TAG_SHARE_FRAGMENT

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/ShareActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/ShareActivity.kt
@@ -75,7 +75,7 @@ class ShareActivity : FileActivity(), ShareFragmentListener {
             if (savedInstanceState == null && file != null && account != null) {
                 // Add Share fragment on first creation
                 // val fragment = ShareFileFragment.newInstance(file, account!!)
-                val fragment = ShareFileComposeFragment.newInstance(file)
+                val fragment = ShareFileComposeFragment.newInstance(file, account)
                 replace(
                     R.id.share_fragment_container, fragment,
                     TAG_SHARE_FRAGMENT

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/ShareActivity.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/ShareActivity.kt
@@ -75,7 +75,7 @@ class ShareActivity : FileActivity(), ShareFragmentListener {
             if (savedInstanceState == null && file != null && account != null) {
                 // Add Share fragment on first creation
                 // val fragment = ShareFileFragment.newInstance(file, account!!)
-                val fragment = ShareFileComposeFragment()
+                val fragment = ShareFileComposeFragment.newInstance(file)
                 replace(
                     R.id.share_fragment_container, fragment,
                     TAG_SHARE_FRAGMENT

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFileComposeFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFileComposeFragment.kt
@@ -214,7 +214,7 @@ class ShareFileComposeFragment : Fragment() {
                                 }
                             )
                         }
-                        if (privateShares.isNullOrEmpty()) {
+                        if (privateShares.isEmpty()) {
                             item { EmptyListText(text = stringResource(id = R.string.share_no_users)) }
                         } else {
                             items(privateShares) { share ->
@@ -242,7 +242,7 @@ class ShareFileComposeFragment : Fragment() {
                             // Show or hide button for adding a new public share depending on the capabilities and the server version
                             SectionHeader(
                                 title = stringResource(id = R.string.share_via_link_section_title),
-                                showAddButton = isMultiplePublicSharingEnabled || (!isMultiplePublicSharingEnabled && publicShares.isNullOrEmpty()),
+                                showAddButton = isMultiplePublicSharingEnabled || (!isMultiplePublicSharingEnabled && publicShares.isEmpty()),
                                 onClickAddButton = {
                                     // Show Add Public Link Fragment
                                     listener?.showAddPublicShare(availableDefaultPublicName(publicShares))
@@ -253,7 +253,7 @@ class ShareFileComposeFragment : Fragment() {
                         if (shareWarningAllowed) {
                             item { WarningText() }
                         }
-                        if (publicShares.isNullOrEmpty()) {
+                        if (publicShares.isEmpty()) {
                             item { EmptyListText(text = stringResource(id = R.string.share_no_public_links)) }
                         } else {
                             items(publicShares) { share ->

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFileComposeFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFileComposeFragment.kt
@@ -536,8 +536,7 @@ class ShareFileComposeFragment : Fragment() {
         Row(
             verticalAlignment = Alignment.CenterVertically
         ) {
-            var name = if (share.name.isNullOrEmpty()) share.token else share.name
-            if (share.shareType == ShareType.GROUP) name = getString(R.string.share_group_clarification, name)
+            val name = if (share.name.isNullOrEmpty()) share.token else share.name
             Text(
                 text = name!!,
                 fontSize = dimensionResource(id = R.dimen.two_line_primary_text_size).value.sp,

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFileComposeFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFileComposeFragment.kt
@@ -430,7 +430,10 @@ class ShareFileComposeFragment : Fragment() {
         ) {
             Text(
                 text = title.uppercase(),
-                modifier = Modifier.padding(start = dimensionResource(id = R.dimen.standard_half_padding)),
+                modifier = Modifier.padding(
+                    start = dimensionResource(id = R.dimen.standard_half_padding),
+                    top = 15.dp,
+                    bottom = 15.dp),
                 color = colorResource(id = R.color.white),
                 fontWeight = FontWeight.Bold
             )

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFileComposeFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFileComposeFragment.kt
@@ -24,6 +24,7 @@
 
 package com.owncloud.android.presentation.ui.sharing.fragments
 
+import android.accounts.Account
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -36,19 +37,15 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.graphics.painter.BitmapPainter
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -58,6 +55,7 @@ import com.owncloud.android.datamodel.OCFile
 import com.owncloud.android.datamodel.ThumbnailsCacheManager
 import com.owncloud.android.utils.DisplayUtils
 import com.owncloud.android.utils.MimetypeIconUtil
+import com.owncloud.android.utils.PreferenceUtils
 
 /**
  * Fragment for sharing a file with sharees (users or groups) or creating
@@ -77,10 +75,16 @@ class ShareFileComposeFragment: Fragment() {
      */
     private var file: OCFile? = null
 
+    /**
+     * OC account holding the file to share, received as a parameter in construction time
+     */
+    private var account: Account? = null
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         arguments?.let {
             file = it.getParcelable(ARG_FILE)
+            account = it.getParcelable(ARG_ACCOUNT)
         }
     }
 
@@ -90,6 +94,7 @@ class ShareFileComposeFragment: Fragment() {
         savedInstanceState: Bundle?
     ): View {
         return ComposeView(requireContext()).apply {
+            filterTouchesWhenObscured = PreferenceUtils.shouldDisallowTouchesWithOtherVisibleWindows(requireContext())
             setContent {
                 setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
                 Column(
@@ -154,6 +159,7 @@ class ShareFileComposeFragment: Fragment() {
          * The fragment initialization parameters
          */
         private const val ARG_FILE = "FILE"
+        private const val ARG_ACCOUNT = "ACCOUNT"
 
         /**
          * Public factory method to create new ShareFileFragment instances.
@@ -163,10 +169,12 @@ class ShareFileComposeFragment: Fragment() {
          * @return A new instance of fragment ShareFileFragment.
          */
         fun newInstance(
-            fileToShare: OCFile
+            fileToShare: OCFile,
+            account: Account
         ): ShareFileComposeFragment {
             val args = Bundle().apply {
                 putParcelable(ARG_FILE, fileToShare)
+                putParcelable(ARG_ACCOUNT, account)
             }
             return ShareFileComposeFragment().apply { arguments = args }
         }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFileComposeFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFileComposeFragment.kt
@@ -434,11 +434,6 @@ class ShareFileComposeFragment: Fragment() {
             modifier = Modifier
                 .fillMaxWidth()
                 .background(color = colorResource(id = R.color.actionbar_start_color))
-                .padding(
-                    end = dimensionResource(id = R.dimen.standard_half_margin),
-                    top = dimensionResource(id = R.dimen.standard_quarter_margin),
-                    bottom = dimensionResource(id = R.dimen.standard_quarter_margin)
-                )
         ) {
             Text(
                 text = title.uppercase(),
@@ -448,8 +443,7 @@ class ShareFileComposeFragment: Fragment() {
             )
             if (showAddButton) {
                 IconButton(
-                    onClick = onClickAddButton,
-                    modifier = Modifier.then(Modifier.size(32.dp))
+                    onClick = onClickAddButton
                 ) {
                     Icon(
                         painter = painterResource(id = R.drawable.ic_add),

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFileComposeFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFileComposeFragment.kt
@@ -487,8 +487,7 @@ class ShareFileComposeFragment : Fragment() {
                 modifier = Modifier
                     .padding(
                         top = dimensionResource(id = R.dimen.standard_half_margin),
-                        bottom = dimensionResource(id = R.dimen.standard_half_margin),
-                        start = dimensionResource(id = R.dimen.standard_half_margin)
+                        bottom = dimensionResource(id = R.dimen.standard_half_margin)
                     )
                     .weight(1f)
             )

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFileComposeFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFileComposeFragment.kt
@@ -87,7 +87,7 @@ import java.util.Locale
  * [ShareFragmentListener] interface
  * to handle interaction events.
  *
- * Use the [ShareFileFragment.newInstance] factory method to
+ * Use the [ShareFileComposeFragment.newInstance] factory method to
  * create an instance of this fragment.
  */
 class ShareFileComposeFragment: Fragment() {

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFileComposeFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFileComposeFragment.kt
@@ -30,13 +30,18 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.Icon
+import androidx.compose.material.IconButton
 import androidx.compose.material.Text
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -46,6 +51,8 @@ import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.colorResource
 import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -98,7 +105,9 @@ class ShareFileComposeFragment: Fragment() {
             setContent {
                 setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
                 Column(
-                    modifier = Modifier.verticalScroll(rememberScrollState())
+                    modifier = Modifier
+                        .verticalScroll(rememberScrollState())
+                        .padding(bottom = dimensionResource(id = R.dimen.standard_padding))
                 ) {
                     Row(
                         verticalAlignment = Alignment.CenterVertically,
@@ -123,7 +132,9 @@ class ShareFileComposeFragment: Fragment() {
                             )
                         }
                         Column(
-                            modifier = Modifier.weight(1f).padding(start = 12.dp)
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(start = 12.dp)
                         ) {
                             Text(
                                 text = file?.fileName!!,
@@ -137,18 +148,118 @@ class ShareFileComposeFragment: Fragment() {
                                 Text(
                                     text = DisplayUtils.bytesToHumanReadable(file!!.fileLength, activity),
                                     fontSize = 12.sp,
-                                    color = colorResource(id = R.color.half_black),
+                                    color = colorResource(id = R.color.half_black)
                                 )
                             }
                         }
-                        Image(
-                            painter = painterResource(id = R.drawable.copy_link),
-                            contentDescription = null,
+                        IconButton(
+                            onClick = { /*TODO*/ },
                             modifier = Modifier
                                 .size(28.dp)
                                 .padding(end = dimensionResource(id = R.dimen.standard_half_padding))
-                        )
+                        ) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.copy_link),
+                                contentDescription = null,
+                                tint = colorResource(id = R.color.half_black)
+                            )
+                        }
                     }
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(color = colorResource(id = R.color.actionbar_start_color))
+                            .padding(
+                                end = dimensionResource(id = R.dimen.standard_half_margin),
+                                top = dimensionResource(id = R.dimen.standard_quarter_margin),
+                                bottom = dimensionResource(id = R.dimen.standard_quarter_margin)
+                            )
+                    ) {
+                        Text(
+                            text = stringResource(id = R.string.share_with_user_section_title).uppercase(),
+                            modifier = Modifier.padding(start = dimensionResource(id = R.dimen.standard_half_padding)),
+                            color = colorResource(id = R.color.white),
+                            fontWeight = FontWeight.Bold
+                        )
+                        IconButton(
+                            onClick = { /*TODO*/ },
+                            modifier = Modifier.then(Modifier.size(32.dp))
+                        ) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.ic_add),
+                                contentDescription = null,
+                                tint = colorResource(id = R.color.white)
+                            )
+                        }
+                    }
+                    Text(
+                        text = stringResource(id = R.string.share_no_users),
+                        fontSize = 15.sp,
+                        color = colorResource(id = R.color.half_black),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(
+                                start = dimensionResource(id = R.dimen.standard_half_padding),
+                                top = dimensionResource(id = R.dimen.standard_padding),
+                                bottom = dimensionResource(id = R.dimen.standard_padding)
+                            )
+                    )
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(color = colorResource(id = R.color.actionbar_start_color))
+                            .padding(
+                                end = dimensionResource(id = R.dimen.standard_half_margin),
+                                top = dimensionResource(id = R.dimen.standard_quarter_margin),
+                                bottom = dimensionResource(id = R.dimen.standard_quarter_margin)
+                            )
+                    ) {
+                        Text(
+                            text = stringResource(id = R.string.share_via_link_section_title).uppercase(),
+                            modifier = Modifier.padding(start = dimensionResource(id = R.dimen.standard_half_padding)),
+                            color = colorResource(id = R.color.white),
+                            fontWeight = FontWeight.Bold
+                        )
+                        IconButton(
+                            onClick = { /*TODO*/ },
+                            modifier = Modifier.then(Modifier.size(32.dp))
+                        ) {
+                            Icon(
+                                painter = painterResource(id = R.drawable.ic_add),
+                                contentDescription = null,
+                                tint = colorResource(id = R.color.white)
+                            )
+                        }
+                    }
+                    Text(
+                        text = stringResource(id = R.string.share_warning_about_forwarding_public_links),
+                        fontSize = 15.sp,
+                        color = colorResource(id = R.color.half_black),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .background(color = colorResource(id = R.color.warning_background_color))
+                            .padding(
+                                start = dimensionResource(id = R.dimen.standard_half_padding),
+                                top = dimensionResource(id = R.dimen.standard_padding),
+                                bottom = dimensionResource(id = R.dimen.standard_padding)
+                            )
+                    )
+                    Text(
+                        text = stringResource(id = R.string.share_no_public_links),
+                        fontSize = 15.sp,
+                        color = colorResource(id = R.color.half_black),
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(
+                                start = dimensionResource(id = R.dimen.standard_half_padding),
+                                top = dimensionResource(id = R.dimen.standard_padding),
+                                bottom = dimensionResource(id = R.dimen.standard_padding)
+                            )
+                    )
                 }
             }
         }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFileComposeFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFileComposeFragment.kt
@@ -1,0 +1,26 @@
+package com.owncloud.android.presentation.ui.sharing.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.material.Text
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.fragment.app.Fragment
+
+class ShareFileComposeFragment: Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+                Text("Hello ownCloud")
+                // Compose code
+            }
+        }
+    }
+}

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFileComposeFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFileComposeFragment.kt
@@ -1,3 +1,27 @@
+/**
+ * ownCloud Android client application
+ *
+ * @author masensio
+ * @author David A. Velasco
+ * @author Juan Carlos González Cabrero
+ * @author David González Verdugo
+ * @author Christian Schabesberger
+ * @author Juan Carlos Garrote Gascón
+ * Copyright (C) 2022 ownCloud GmbH.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http:></http:>//www.gnu.org/licenses/>.
+ */
+
 package com.owncloud.android.presentation.ui.sharing.fragments
 
 import android.os.Bundle

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFileComposeFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFileComposeFragment.kt
@@ -4,12 +4,48 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.fragment.app.Fragment
+import com.owncloud.android.R
+import com.owncloud.android.datamodel.OCFile
+import com.owncloud.android.datamodel.ThumbnailsCacheManager
+import com.owncloud.android.utils.DisplayUtils
+import com.owncloud.android.utils.MimetypeIconUtil
 
 class ShareFileComposeFragment: Fragment() {
+
+    private var file: OCFile? = null
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        arguments?.let {
+            file = it.getParcelable(ARG_FILE)
+        }
+    }
+
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
@@ -18,9 +54,73 @@ class ShareFileComposeFragment: Fragment() {
         return ComposeView(requireContext()).apply {
             setContent {
                 setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
-                Text("Hello ownCloud")
-                // Compose code
+                Column(
+                    modifier = Modifier.verticalScroll(rememberScrollState())
+                ) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        modifier = Modifier.padding(dimensionResource(id = R.dimen.standard_padding))
+                    ) {
+                        val thumbnail = ThumbnailsCacheManager.getBitmapFromDiskCache(file?.remoteId.toString())
+                        if (file!!.isImage && thumbnail != null) {
+                            Image(
+                                bitmap = thumbnail.asImageBitmap(),
+                                contentDescription = null,
+                                modifier = Modifier
+                                    .size(dimensionResource(id = R.dimen.file_icon_size))
+                                    .fillMaxSize()
+                            )
+                        } else {
+                            Image(
+                                painter = painterResource(id = MimetypeIconUtil.getFileTypeIconId(file?.mimetype, file?.fileName)),
+                                contentDescription = null,
+                                modifier = Modifier
+                                    .size(dimensionResource(id = R.dimen.file_icon_size))
+                                    .fillMaxSize()
+                            )
+                        }
+                        Column(
+                            modifier = Modifier.weight(1f).padding(start = 12.dp)
+                        ) {
+                            Text(
+                                text = file?.fileName!!,
+                                fontSize = 16.sp,
+                                color = colorResource(id = R.color.black),
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                                modifier = Modifier.padding(end = dimensionResource(id = R.dimen.standard_half_margin))
+                            )
+                            if (!file!!.isFolder) {
+                                Text(
+                                    text = DisplayUtils.bytesToHumanReadable(file!!.fileLength, activity),
+                                    fontSize = 12.sp,
+                                    color = colorResource(id = R.color.half_black),
+                                )
+                            }
+                        }
+                        Image(
+                            painter = painterResource(id = R.drawable.copy_link),
+                            contentDescription = null,
+                            modifier = Modifier
+                                .size(28.dp)
+                                .padding(end = dimensionResource(id = R.dimen.standard_half_padding))
+                        )
+                    }
+                }
             }
+        }
+    }
+
+    companion object {
+        private const val ARG_FILE = "FILE"
+
+        fun newInstance(
+            fileToShare: OCFile
+        ): ShareFileComposeFragment {
+            val args = Bundle().apply {
+                putParcelable(ARG_FILE, fileToShare)
+            }
+            return ShareFileComposeFragment().apply { arguments = args }
         }
     }
 }

--- a/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFileComposeFragment.kt
+++ b/owncloudApp/src/main/java/com/owncloud/android/presentation/ui/sharing/fragments/ShareFileComposeFragment.kt
@@ -59,8 +59,22 @@ import com.owncloud.android.datamodel.ThumbnailsCacheManager
 import com.owncloud.android.utils.DisplayUtils
 import com.owncloud.android.utils.MimetypeIconUtil
 
+/**
+ * Fragment for sharing a file with sharees (users or groups) or creating
+ * a public link.
+ *
+ * Activities that contain this fragment must implement the
+ * [ShareFragmentListener] interface
+ * to handle interaction events.
+ *
+ * Use the [ShareFileFragment.newInstance] factory method to
+ * create an instance of this fragment.
+ */
 class ShareFileComposeFragment: Fragment() {
 
+    /**
+     * File to share, received as a parameter in construction time
+     */
     private var file: OCFile? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -136,8 +150,18 @@ class ShareFileComposeFragment: Fragment() {
     }
 
     companion object {
+        /**
+         * The fragment initialization parameters
+         */
         private const val ARG_FILE = "FILE"
 
+        /**
+         * Public factory method to create new ShareFileFragment instances.
+         *
+         * @param fileToShare An [OCFile] to show in the fragment
+         * @param account     An ownCloud account
+         * @return A new instance of fragment ShareFileFragment.
+         */
         fun newInstance(
             fileToShare: OCFile
         ): ShareFileComposeFragment {


### PR DESCRIPTION
``ShareFileFragment`` moved to Jetpack Compose
_____

## QA

###  Sharing 

**Device**: Pixel5, Android12 <br>
**Server**: 10.10.0 <br>
**Base commit**: `f7c4c997` (compose_shares) <br>
**Authentication**: Basic auth

---

 
| Test Case | Description | Expected | Result | Comment |
| :-------- | :---------- | :------- | :-----: | :------
| **Private Share** |   |  |
| Shared with one user| Select to share a file whose name contains special characters with a user whose name includes special characters| Check that user2 has access to the file<br>Check that the file includes the individual share icon | :white_check_mark: |  |
| Shared with one group| Select to share a file with a group whose name includes special characters| Check that everyone in the group has access to the file<br>Check that the file includes the group share icon | :white_check_mark: |  | 
| Shared with several | Select to share a file with several users and groups | Check that every sharee has access to the file<br>Check that the shares includes the correct individual/group icon |  :white_check_mark:|  |
| Share with users + Share with link | 1. Select an item to share with several users<br>2. Select same item to share by link, creating several links | Check that the link works<br>Check, at least one user have still access to the file | :white_check_mark:  |  |
| Federated Share | Share a folder with a user in other server (reachable) | Check that the user can see the file in the list | :white_check_mark:  |  |
| Edit | 1. Previously shared item with a user<br>2. Click on the pencil icon to edit<br>3. Remove permissions| Check in server that the share does not have any permissions | :white_check_mark: |  |
| Delete | 1. Previously shared item with several users<br>2. Unshare one of the sharees<br>| The share with individual icon is no longer displayed<br>User does not have access to the folder any more<br>Other shares do not change| :white_check_mark: |  |
| Delete all | Delete all sharees form an item| Empty list of shares | :white_check_mark:  |  |
| **Public Share** |   |  |
| Share by link | 1. Share a item by link<br>2. Access using a web browser to the link | 1. Link is generated and options to share are shown<br>2. Link works | :white_check_mark: |  |
| Unshare by link | Select to unshare the previous file | Link icon is not shown. Link doesn't work | :white_check_mark: |  |
| Multiple links | Create several public links on the same item | Check that all of them are correctly generated in server | :white_check_mark: |  |
| Edit | 1. Links created before<br>2. Click on the pencil icon to edit<br>3. Add password and expiration date| Check in server that the link has the correct expiration date and password | :white_check_mark: |  |
| Remove links | After creating a huge amount of links in the same file, remove some of them | Check in server that removed links do not appear anymore | :white_check_mark: |  |
| Remove all links | After creating a huge amount of links in the same file, remove all of them | Empty list of links | :white_check_mark: |  |
| **Capabilities** |   |  |
| Server doesn't support share api | 1. In server, select to disable the share API<br>2. From the app, try to share a file/folder | Sharing option does not appear, only private link. | :white_check_mark: |
| Server doesn't support public links | 1. In sever, select to disable the public link API<br>2. From the app, try to share by link a file/folder  | Only private link and private share | :white_check_mark: |  |
| Extra field = None | Set extra field = none<br>Create private share | Results do not show nothing extra | :white_check_mark: |  |
| Extra field = User ID | Set extra field = User ID<br>Create private share | User ID is shown in results | :white_check_mark: |  |
| Extra field = Email | Set extra field = Email<br>Create private share | Email is shown in results | :white_check_mark: |  |